### PR TITLE
Rename immutablemultidict implementations

### DIFF
--- a/immutablecollections/_immutablemultidict.py
+++ b/immutablecollections/_immutablemultidict.py
@@ -15,7 +15,7 @@ from typing import (
     TypeVar,
     Union,
     ValuesView,
-)  # pylint:disable=unused-import
+)
 
 from immutablecollections import (
     immutabledict,
@@ -222,7 +222,6 @@ class ImmutableSetMultiDict(ImmutableMultiDict[KT, VT], metaclass=ABCMeta):
     # want to specify a sorting method.
 
     # Signature of the of method varies by collection
-    # pylint: disable = arguments-differ
     @staticmethod
     def of(
         data: Union[Mapping[KT, Iterable[VT]], Iterable[IT]]
@@ -415,7 +414,7 @@ class _ImmutableDictBackedImmutableSetMultiDict(ImmutableSetMultiDict[KT, VT]):
         """
         return self._dict.values()
 
-    def __len__(self) -> int:  # pylint:disable=invalid-length-returned
+    def __len__(self) -> int:
         """
         Get the number of key-value mappings in this multidict.
         """
@@ -438,7 +437,6 @@ class ImmutableListMultiDict(ImmutableMultiDict[KT, VT], metaclass=ABCMeta):
     __slots__ = ()
 
     # Signature of the of method varies by collection
-    # pylint: disable = arguments-differ
     @staticmethod
     def of(
         data: Union[Mapping[KT, Iterable[VT]], Iterable[IT]]
@@ -600,13 +598,13 @@ _EMPTY_IMMUTABLE_LIST: ImmutableList[Any] = immutablelist()
 class _ImmutableDictBackedImmutableListMultiDict(ImmutableListMultiDict[KT, VT]):
     __slots__ = "_dict", "_len"
 
-    # pylint:disable=assigning-non-slot,redefined-builtin
+    # pylint:disable=assigning-non-slot
     def __init__(
-        self, dict: Mapping[KT, ImmutableList[VT]], len: Optional[int] = None
+        self, init_dict: Mapping[KT, ImmutableList[VT]], init_len: Optional[int] = None
     ) -> None:
         super(_ImmutableDictBackedImmutableListMultiDict, self).__init__()
-        self._dict = _freeze_list_multidict(dict)
-        self._len = len
+        self._dict = _freeze_list_multidict(init_dict)
+        self._len = init_len
 
     def as_dict(self) -> Mapping[KT, ImmutableList[VT]]:
         return self._dict
@@ -614,7 +612,7 @@ class _ImmutableDictBackedImmutableListMultiDict(ImmutableListMultiDict[KT, VT])
     def __getitem__(self, k: KT) -> ImmutableList[VT]:
         return self._dict.get(k, _EMPTY_IMMUTABLE_LIST)
 
-    def __len__(self) -> int:  # pylint:disable=invalid-length-returned
+    def __len__(self) -> int:
         """
         Get the number of key-value mappings in this multidict.
         """

--- a/immutablecollections/_immutablemultidict.py
+++ b/immutablecollections/_immutablemultidict.py
@@ -372,7 +372,7 @@ class ImmutableSetMultiDict(ImmutableMultiDict[KT, VT], metaclass=ABCMeta):
             if self._dirty or self._source is None:
                 result: ImmutableSetMultiDict[
                     KT2, VT2
-                ] = FrozenDictBackedImmutableSetMultiDict(
+                ] = _ImmutableDictBackedImmutableSetMultiDict(
                     {k: v.build() for (k, v) in self._dict.items()}  # type: ignore
                 )
                 # item type doesn't matter on empty collections
@@ -390,14 +390,14 @@ def _freeze_set_multidict(x: Mapping[KT, Iterable[VT]]) -> Mapping[KT, Immutable
     return immutabledict(((k, immutableset(v)) for (k, v) in x.items()))
 
 
-class FrozenDictBackedImmutableSetMultiDict(ImmutableSetMultiDict[KT, VT]):
+class _ImmutableDictBackedImmutableSetMultiDict(ImmutableSetMultiDict[KT, VT]):
     __slots__ = "_dict", "_len"
 
     # pylint:disable=assigning-non-slot
     def __init__(
         self, init_dict: Mapping[KT, ImmutableSet[VT]], init_len: Optional[int] = None
     ) -> None:
-        super(FrozenDictBackedImmutableSetMultiDict, self).__init__()
+        super(_ImmutableDictBackedImmutableSetMultiDict, self).__init__()
         self._dict = _freeze_set_multidict(init_dict)
         # The length (total number of key-value mappings) is cached
         # to avoid unnecessary length calls to immutable (unchanging) value groups.
@@ -430,7 +430,7 @@ class FrozenDictBackedImmutableSetMultiDict(ImmutableSetMultiDict[KT, VT]):
 
 
 # Singleton instance for empty
-_SET_EMPTY: ImmutableSetMultiDict = FrozenDictBackedImmutableSetMultiDict({})
+_SET_EMPTY: ImmutableSetMultiDict = _ImmutableDictBackedImmutableSetMultiDict({})
 
 
 # needs tests: issue #127
@@ -575,7 +575,7 @@ class ImmutableListMultiDict(ImmutableMultiDict[KT, VT], metaclass=ABCMeta):
             if self._dirty or self._source is None:
                 result: ImmutableListMultiDict[
                     KT2, VT2
-                ] = FrozenDictBackedImmutableListMultiDict(
+                ] = _ImmutableDictBackedImmutableListMultiDict(
                     {k: v.build() for (k, v) in self._dict.items()}  # type: ignore
                 )
                 return (
@@ -597,14 +597,14 @@ def _freeze_list_multidict(
 _EMPTY_IMMUTABLE_LIST: ImmutableList[Any] = immutablelist()
 
 
-class FrozenDictBackedImmutableListMultiDict(ImmutableListMultiDict[KT, VT]):
+class _ImmutableDictBackedImmutableListMultiDict(ImmutableListMultiDict[KT, VT]):
     __slots__ = "_dict", "_len"
 
     # pylint:disable=assigning-non-slot,redefined-builtin
     def __init__(
         self, dict: Mapping[KT, ImmutableList[VT]], len: Optional[int] = None
     ) -> None:
-        super(FrozenDictBackedImmutableListMultiDict, self).__init__()
+        super(_ImmutableDictBackedImmutableListMultiDict, self).__init__()
         self._dict = _freeze_list_multidict(dict)
         self._len = len
 
@@ -626,8 +626,10 @@ class FrozenDictBackedImmutableListMultiDict(ImmutableListMultiDict[KT, VT]):
 
 
 # Singleton instance for empty
-_EMPTY_IMMUTABLE_SET_MULTIDICT = FrozenDictBackedImmutableSetMultiDict({})  # type: ignore
-_EMPTY_IMMUTABLE_LIST_MULTIDICT = FrozenDictBackedImmutableListMultiDict(  # type: ignore
+_EMPTY_IMMUTABLE_SET_MULTIDICT = _ImmutableDictBackedImmutableSetMultiDict(  # type: ignore
+    {}
+)
+_EMPTY_IMMUTABLE_LIST_MULTIDICT = _ImmutableDictBackedImmutableListMultiDict(  # type: ignore
     {}
 )
 

--- a/tests/test_immutablemultidict.py
+++ b/tests/test_immutablemultidict.py
@@ -161,7 +161,7 @@ class TestImmutableListMultiDict(TestCase):
 
     def test_immutable_keys(self):
         x = ImmutableListMultiDict.of({1: [2, 2, 3], 4: [5, 6]})
-        # TypeError: 'FrozenDictBackedImmutableListMultiDict' object does not support item
+        # TypeError: '_ImmutableDictBackedImmutableListMultiDict' object does not support item
         # assignment
         with self.assertRaises(TypeError):
             # noinspection PyUnresolvedReferences


### PR DESCRIPTION
A follow-up to https://github.com/isi-vista/immutablecollections/pull/40, where `Frozen` was kept in the name of multidict implementations even though they were no longer backed by `frozendicts`.